### PR TITLE
Add ERC721 and ERC1155 support

### DIFF
--- a/contracts/interfaces/IERC1155.sol
+++ b/contracts/interfaces/IERC1155.sol
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IERC1155 {
+    event TransferSingle(
+        address indexed operator,
+        address indexed from,
+        address indexed to,
+        uint256 id,
+        uint256 value
+    );
+
+    event TransferBatch(
+        address indexed operator,
+        address indexed from,
+        address indexed to,
+        uint256[] ids,
+        uint256[] values
+    );
+
+    event ApprovalForAll(
+        address indexed account,
+        address indexed operator,
+        bool approved
+    );
+
+    event URI(string value, uint256 indexed id);
+
+    function balanceOf(address account, uint256 id) external view returns (uint256);
+    function balanceOfBatch(address[] calldata accounts, uint256[] calldata ids)
+        external
+        view
+        returns (uint256[] memory);
+    function setApprovalForAll(address operator, bool approved) external;
+    function isApprovedForAll(address account, address operator) external view returns (bool);
+    function safeTransferFrom(
+        address from,
+        address to,
+        uint256 id,
+        uint256 amount,
+        bytes calldata data
+    ) external;
+    function safeBatchTransferFrom(
+        address from,
+        address to,
+        uint256[] calldata ids,
+        uint256[] calldata amounts,
+        bytes calldata data
+    ) external;
+}

--- a/contracts/interfaces/IERC721.sol
+++ b/contracts/interfaces/IERC721.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+interface IERC721 {
+    event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);
+    event Approval(address indexed owner, address indexed approved, uint256 indexed tokenId);
+    event ApprovalForAll(address indexed owner, address indexed operator, bool approved);
+
+    function balanceOf(address owner) external view returns (uint256 balance);
+    function ownerOf(uint256 tokenId) external view returns (address owner);
+    function safeTransferFrom(address from, address to, uint256 tokenId, bytes calldata data) external;
+    function safeTransferFrom(address from, address to, uint256 tokenId) external;
+    function transferFrom(address from, address to, uint256 tokenId) external;
+    function approve(address to, uint256 tokenId) external;
+    function setApprovalForAll(address operator, bool approved) external;
+    function getApproved(uint256 tokenId) external view returns (address operator);
+    function isApprovedForAll(address owner, address operator) external view returns (bool);
+}

--- a/lib/commitment.js
+++ b/lib/commitment.js
@@ -1,8 +1,9 @@
-// { asset: address, amount: uint256, salt: uint256, owner: address }
+// { asset: address, amount: uint256, salt: uint256, owner: address, tokenId: uint256, tokenType: uint8 }
 class Commitment {
-    _zeroPadConvertUint8Array(x) { return ethers.getBytes(ethers.zeroPadValue(ethers.getBytes(ethers.toBeArray(x)), 32)); } // XXX
+    _zeroPadConvertUint8Array(x) { return ethers.getBytes(ethers.zeroPadValue(ethers.getBytes(ethers.toBeArray(x)), 32)); }
 
-    constructor(asset, amount, salt, owner = null, index = null) {
+    // TokenType: 0 = ERC20, 1 = ERC721, 2 = ERC1155
+    constructor(asset, amount, salt, owner = null, index = null, tokenId = 0, tokenType = 0) {
         if (!owner) owner = 0;
 
         this.asset = asset;
@@ -10,6 +11,36 @@ class Commitment {
         this.salt = salt;
         this.owner = owner;
         this.index = index;
+        this.tokenId = tokenId;
+        this.tokenType = tokenType;
+
+        // Validate token type specific rules
+        this._validateTokenRules();
+    }
+
+    _validateTokenRules() {
+        switch (this.tokenType) {
+            case 1: // ERC721
+                if (this.amount !== 0 && this.amount !== 1) {
+                    throw new Error('ERC721 tokens can only have amount of 0 or 1');
+                }
+                if (this.tokenId === 0) {
+                    throw new Error('ERC721 tokens must have a valid tokenId');
+                }
+                break;
+            case 2: // ERC1155
+                if (this.tokenId === 0) {
+                    throw new Error('ERC1155 tokens must have a valid tokenId');
+                }
+                break;
+            case 0: // ERC20
+                if (this.tokenId !== 0) {
+                    throw new Error('ERC20 tokens should not have a tokenId');
+                }
+                break;
+            default:
+                throw new Error('Invalid token type');
+        }
     }
 
     nullifierHash(proofGeneration) {
@@ -17,9 +48,10 @@ class Commitment {
             this.asset,
             this.amount,
             this.salt,
-            this.owner
+            this.owner,
+            this.tokenId,
+            this.tokenType
         ]);
-        //console.log('nullifier hash result', result, [this.asset, this.amount, this.salt])
         return result;
     }
 
@@ -29,7 +61,21 @@ class Commitment {
             this.salt
         ]);
     }
-}
 
+    // Helper method to create ERC721 commitment
+    static createERC721(asset, tokenId, salt, owner = null, index = null) {
+        return new Commitment(asset, 1, salt, owner, index, tokenId, 1);
+    }
+
+    // Helper method to create ERC1155 commitment
+    static createERC1155(asset, tokenId, amount, salt, owner = null, index = null) {
+        return new Commitment(asset, amount, salt, owner, index, tokenId, 2);
+    }
+
+    // Helper method to create ERC20 commitment (for backward compatibility)
+    static createERC20(asset, amount, salt, owner = null, index = null) {
+        return new Commitment(asset, amount, salt, owner, index, 0, 0);
+    }
+}
 
 module.exports = { Commitment }

--- a/test/unit/commitment-test.js
+++ b/test/unit/commitment-test.js
@@ -1,0 +1,120 @@
+const { expect } = require("chai");
+const { Commitment } = require('../../lib/commitment.js');
+
+describe("Commitment Tests", function () {
+    const mockProofGeneration = {
+        poseidon: (inputs) => inputs.reduce((a, b) => a + b, 0) // Simple mock for testing
+    };
+
+    describe("ERC721 Commitments", () => {
+        it("should create valid ERC721 commitment", () => {
+            const commitment = Commitment.createERC721(
+                "0x123",  // asset address
+                1,        // tokenId
+                123456,   // salt
+                "0x456"   // owner
+            );
+
+            expect(commitment.tokenType).to.equal(1);
+            expect(commitment.amount).to.equal(1);
+            expect(commitment.tokenId).to.equal(1);
+        });
+
+        it("should reject invalid ERC721 amount", () => {
+            expect(() => new Commitment(
+                "0x123",  // asset
+                2,        // amount (invalid for ERC721)
+                123456,   // salt
+                "0x456",  // owner
+                null,     // index
+                1,        // tokenId
+                1         // tokenType (ERC721)
+            )).to.throw('ERC721 tokens can only have amount of 0 or 1');
+        });
+
+        it("should reject ERC721 with zero tokenId", () => {
+            expect(() => new Commitment(
+                "0x123", // asset
+                1,       // amount
+                123456,  // salt
+                "0x456", // owner
+                null,    // index
+                0,       // tokenId (invalid)
+                1        // tokenType (ERC721)
+            )).to.throw('ERC721 tokens must have a valid tokenId');
+        });
+    });
+
+    describe("ERC1155 Commitments", () => {
+        it("should create valid ERC1155 commitment", () => {
+            const commitment = Commitment.createERC1155(
+                "0x123",  // asset address
+                1,        // tokenId
+                5,        // amount
+                123456,   // salt
+                "0x456"   // owner
+            );
+
+            expect(commitment.tokenType).to.equal(2);
+            expect(commitment.amount).to.equal(5);
+            expect(commitment.tokenId).to.equal(1);
+        });
+
+        it("should reject ERC1155 with zero tokenId", () => {
+            expect(() => new Commitment(
+                "0x123", // asset
+                5,       // amount
+                123456,  // salt
+                "0x456", // owner
+                null,    // index
+                0,       // tokenId (invalid)
+                2        // tokenType (ERC1155)
+            )).to.throw('ERC1155 tokens must have a valid tokenId');
+        });
+    });
+
+    describe("ERC20 Commitments (Backward Compatibility)", () => {
+        it("should create valid ERC20 commitment", () => {
+            const commitment = Commitment.createERC20(
+                "0x123",  // asset address
+                100,      // amount
+                123456,   // salt
+                "0x456"   // owner
+            );
+
+            expect(commitment.tokenType).to.equal(0);
+            expect(commitment.amount).to.equal(100);
+            expect(commitment.tokenId).to.equal(0);
+        });
+
+        it("should reject ERC20 with non-zero tokenId", () => {
+            expect(() => new Commitment(
+                "0x123", // asset
+                100,     // amount
+                123456,  // salt
+                "0x456", // owner
+                null,    // index
+                1,       // tokenId (invalid for ERC20)
+                0        // tokenType (ERC20)
+            )).to.throw('ERC20 tokens should not have a tokenId');
+        });
+    });
+
+    describe("Commitment Hashing", () => {
+        it("should include tokenId and tokenType in nullifier hash", () => {
+            const commitment = new Commitment(
+                123,      // asset (numeric for testing)
+                1,        // amount
+                456,      // salt
+                789,      // owner
+                null,     // index
+                1,        // tokenId
+                1        // tokenType (ERC721)
+            );
+
+            const hash = commitment.nullifierHash(mockProofGeneration);
+            // Sum of all inputs: 123 + 1 + 456 + 789 + 1 + 1 = 1371
+            expect(hash).to.equal(1371);
+        });
+    });
+});


### PR DESCRIPTION
# Add Support for ERC721 and ERC1155 Tokens

This PR addresses issue #3 by adding support for NFTs (ERC721) and Multi-tokens (ERC1155).

## Changes Made
- Add IERC1155 interface definition
- Extend Commitment class to support different token types:
  - ERC721 (NFTs)
  - ERC1155 (Multi-tokens)
  - Maintain backward compatibility with ERC20
- Add token type validation rules
- Add helper methods for creating different token type commitments
- Add comprehensive test suite

## Features
- Support for NFT commitments with tokenId
- Support for ERC1155 multi-token commitments
- Validation rules specific to each token type
- Backward compatibility with existing ERC20 functionality
- Helper methods for easy commitment creation

## Testing
Added unit tests that verify:
- ERC721 commitment creation and validation
- ERC1155 commitment creation and validation
- ERC20 backward compatibility
- Token type specific validation rules
- Commitment hashing with new fields

All tests are passing and show the new functionality working as expected.

## Documentation
Added comments and documentation for:
- Token type constants
- Validation rules
- Helper methods